### PR TITLE
Enabled github pages for rdf4j repo

### DIFF
--- a/otterdog/eclipse-rdf4j.jsonnet
+++ b/otterdog/eclipse-rdf4j.jsonnet
@@ -51,6 +51,7 @@ orgs.newOrg('technology.rdf4j', 'eclipse-rdf4j') {
       merge_commit_message: "BLANK",
       merge_commit_title: "PR_TITLE",
       squash_merge_commit_title: "PR_TITLE",
+      gh_pages_build_type: "workflow",
       topics+: [
         "hacktoberfest",
         "java",


### PR DESCRIPTION
We would like to host our website https://rdf4j.org through github pages instead of having a dedicated server for this. First step would be to enable github pages with support for a workflow.