### PR TITLE
migrate to java 25

### DIFF
--- a/otterdog/eclipse-rdf4j.jsonnet
+++ b/otterdog/eclipse-rdf4j.jsonnet
@@ -104,14 +104,14 @@ orgs.newOrg('technology.rdf4j', 'eclipse-rdf4j') {
         orgs.newBranchProtectionRule('develop') {
           required_approving_review_count: null,
           required_status_checks+: [
-            "any:build (11)"
+            "any:build (25)"
           ],
           requires_pull_request: false,
         },
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: null,
           required_status_checks+: [
-            "any:build (11)"
+            "any:build (25)"
           ],
           requires_pull_request: false,
         },


### PR DESCRIPTION
Updated branch protection rules to use build (25) instead of build (11).